### PR TITLE
Print correct ctrlz listening address

### DIFF
--- a/pkg/ctrlz/ctrlz.go
+++ b/pkg/ctrlz/ctrlz.go
@@ -189,13 +189,13 @@ func Run(o *Options, customTopics []fw.Topic) (*Server, error) {
 	}
 
 	s.shutdown.Add(1)
-	go s.listen(o.Port)
+	go s.listen()
 
 	return s, nil
 }
 
-func (s *Server) listen(port uint16) {
-	log.Infof("ControlZ available at %s:%d", getLocalIP(), port)
+func (s *Server) listen() {
+	log.Infof("ControlZ available at %s", s.listener.Addr().String())
 
 	if listeningTestProbe != nil {
 		listeningTestProbe()


### PR DESCRIPTION
Print correct `ctrlz` listening address. When "--ctrlz_address" not set value, we use default address "127.0.0.1".  

```
func (s *Server) listen(port uint16) {
    log.Infof("ControlZ available at %s:%d", getLocalIP(), port)  // Print non-local IP Address, but we use "127.0.0.1" now!
    // So we'd better get the address from `s.listener.Addr()`
    // log.Infof("ControlZ available at %s", s.listener.Addr().String())
    // ... 
}
```